### PR TITLE
Update installation and usage instructions, and don't automatically update the Homebrew formula on release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -200,24 +200,6 @@ jobs:
             litra-autotoggle_${{ steps.sanitise_ref.outputs.value }}_darwin-arm64
             litra-autotoggle_${{ steps.sanitise_ref.outputs.value }}_linux-amd64
             litra-autotoggle_${{ steps.sanitise_ref.outputs.value }}_darwin-universal
-  publish_on_homebrew:
-    name: Publish release on Homebrew
-    runs-on: ubuntu-latest
-    needs: create_github_release
-    if: startsWith(github.event.ref, 'refs/tags/v')
-    steps:
-      - name: Get released version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-      - uses: mislav/bump-homebrew-formula-action@v3
-        with:
-          formula-name: litra-autotoggle
-          download-url: https://github.com/timrogers/litra-autotoggle/releases/download/${{ steps.get_version.outputs.VERSION }}/litra-autotoggle_${{ steps.get_version.outputs.VERSION }}_darwin-universal
-          homebrew-tap: timrogers/homebrew-tap
-          push-to: timrogers/homebrew-tap
-          create-pullrequest: true
-        env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
   cargo_publish:
     name: Publish with Cargo to Crates.io
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ The following Logitech Litra devices, **connected via USB**, are supported:
 
 ## Installation
 
-### macOS with [Homebrew](https://brew.sh/)
+### macOS or Linux via [Homebrew](https://brew.sh/)
 
 1. Install the latest version of `litra-autotoggle` by running `brew tap timrogers/tap && brew install litra-autotoggle`.
 1. Run `litra-autotoggle --help` to check that everything is working.
 
-### All other platforms (using Cargo)
+### macOS or Linux via [Cargo](https://doc.rust-lang.org/cargo/), Rust's package manager
 
 1. Install [Rust](https://www.rust-lang.org/tools/install) on your machine, if it isn't already installed.
 1. Install the `litra-autotoggle` crate by running `cargo install litra-autotoggle`.
 1. Run `litra-autotoggle --help` to check that everything is working and see the available commands.
 
-### All other platforms (via binary)
+### macOS or Linux via direct binary download
 
 1. Download the [latest release](https://github.com/timrogers/litra-autotoggle/releases/latest) for your platform. macOS and Linux devices are supported.
 1. Add the binary to `$PATH`, so you can execute it from your shell. For the best experience, call it `litra-autotoggle`.
@@ -33,14 +33,14 @@ The following Logitech Litra devices, **connected via USB**, are supported:
 
 ## Usage
 
-### In the background, using Homebrew Services (macOS with [Homebrew](https://brew.sh/) only)
+### In the background, using Homebrew Services ([Homebrew](https://brew.sh/) installations only)
 
 Run `brew services start timrogers/tap/litra-autotoggle`.
 
 `litra-autotoggle` will run in the background, and your Litra will turn on when your webcam turns on, and off when your webcam turns off. If no Litra device is connected, the listener will keep on running, but will do nothing.
 
 > [!NOTE]
-> When starting the service for the first time, you will receive a notification from macOS warning you about software running in the background.
+> When starting the service for the first time on a macOS device, you will receive a notification warning you about software running in the background.
 
 ![macOS warning](https://github.com/user-attachments/assets/7abd6d99-0481-4684-8079-a6d80e0fcaea)
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following Logitech Litra devices, **connected via USB**, are supported:
 
 ### In the background, using Homebrew Services (macOS with [Homebrew](https://brew.sh/) only)
 
-Run `brew services start litra-autotoggle`.
+Run `brew services start timrogers/tap/litra-autotoggle`.
 
 `litra-autotoggle` will run in the background, and your Litra will turn on when your webcam turns on, and off when your webcam turns off. If no Litra device is connected, the listener will keep on running, but will do nothing.
 


### PR DESCRIPTION
Our Homebrew formula now supports installation on Linux as well as macOS.

This updates the README to make it clear that you can install that way (which is the easiest way!), and makes a few other tweaks along the way.

I also stop automatically updating the Homebrew formula on release - this automation was great, but it doesn't work once you have a more complex formula supporting multiple platforms.