### PR TITLE
Add: video_device clap arg to monitor particular video devices on linux

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,11 @@ struct Cli {
     require_device: bool,
 
     #[cfg(target_os = "linux")]
-    #[clap(long, short = 'd', help = "The path of the video device to monitor (e.g. `/dev/video0`) (Linux only)")]
+    #[clap(
+        long,
+        short = 'd',
+        help = "The path of the video device to monitor (e.g. `/dev/video0`) (Linux only)"
+    )]
     video_device: Option<String>,
 
     #[clap(long, short, action, help = "Output detailed log messages")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ struct Cli {
     require_device: bool,
 
     #[cfg(target_os = "linux")]
-    #[clap(long, short = 'd', help = "The path of the video device to monitor")]
+    #[clap(long, short = 'd', help = "The path of the video device to monitor, example: /dev/video0 (Linux only)")]
     video_device: Option<String>,
 
     #[clap(long, short, action, help = "Output detailed log messages")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ struct Cli {
     require_device: bool,
 
     #[cfg(target_os = "linux")]
-    #[clap(long, short = 'd', help = "The path of the video device to monitor, example: /dev/video0 (Linux only)")]
+    #[clap(long, short = 'd', help = "The path of the video device to monitor (e.g. `/dev/video0`) (Linux only)")]
     video_device: Option<String>,
 
     #[clap(long, short, action, help = "Output detailed log messages")]


### PR DESCRIPTION
I tried to add the mac code but the data coming back for com.apple.cmio is limited.