### PR TITLE
Keep refreshing the list of connected Litra devices, rather than leaning on a cached list from when the tool started + docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Just run `litra-autotoggle`. Your Litra will turn on when your webcam turns on, 
 The following arguments are supported:
 
 - `--serial-number` to point to a specific Litra device. You can get the serial number using the `litra devices` command in the [`litra`](https://github.com/timrogers/litra-rs) CLI.
-- `--require-device` to enforce that a Litra device must be connected. By default, the listener will keep even if no Litra device is found.
+- `--require-device` to enforce that a Litra device must be connected. By default, the listener will keep running even if no Litra device is found.
 - `--video-device` (Linux only) to watch a specific video device (e.g. `/dev/video0`). By default, all video devices will be watched.
 
 ## Configuring `udev` permissions (Linux only)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Just run `litra-autotoggle`. Your Litra will turn on when your webcam turns on, 
 The following arguments are supported:
 
 - `--serial-number` to point to a specific Litra device. You can get the serial number using the `litra devices` command in the [`litra`](https://github.com/timrogers/litra-rs) CLI.
-- `--require-device` to enforce that a Litra device must be connected. By default, the listener will keep running even if no Litra device is found.
+- `--require-device` to enforce that a Litra device must be connected. By default, the listener will keep running even if no Litra device is found. With this set, the listener will exit whenever it looks for a Litra device and none is found.
 - `--video-device` (Linux only) to watch a specific video device (e.g. `/dev/video0`). By default, all video devices will be watched.
 
 ## Configuring `udev` permissions (Linux only)

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ struct Cli {
     #[clap(
         long,
         short = 'd',
-        help = "The path of the video device to monitor (e.g. `/dev/video0`) (Linux only)"
+        help = "The path of the video device to monitor (e.g. `/dev/video0`) (Linux only). By default, all devices are monitored."
     )]
     video_device: Option<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ struct Cli {
         long,
         short,
         action,
-        help = "Exit with an error if no Litra device is found. By default, the program will run and listen for events even if no Litra device is found, but do nothing."
+        help = "Exit with an error if no Litra device is found. By default, the program will run and listen for events even if no Litra device is found, but do nothing. With this option set, the program will exit whenever it looks for a Litra device and none is found."
     )]
     require_device: bool,
 


### PR DESCRIPTION
Fixes #10.