### PR TITLE
v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "litra-autotoggle"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "inotify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litra-autotoggle"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Tim Rogers <timrogers@github.com>"]
 description = "Automatically turn your Logitech Litra device on when your webcam turns on, and off when your webcam turns off (macOS and Linux only)"


### PR DESCRIPTION
* Keep refreshing the list of connected Litra devices, rather than leaning on a cached list from when the tool started
* Improve in-CLI documentation for the `--require-device` and `--video-device` options