### PR TITLE
Add configurable delay on macOS between webcam event detection and Litra toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following arguments are supported:
 - `--serial-number` to point to a specific Litra device. You can get the serial number using the `litra devices` command in the [`litra`](https://github.com/timrogers/litra-rs) CLI.
 - `--require-device` to enforce that a Litra device must be connected. By default, the listener will keep running even if no Litra device is found. With this set, the listener will exit whenever it looks for a Litra device and none is found.
 - `--video-device` (Linux only) to watch a specific video device (e.g. `/dev/video0`). By default, all video devices will be watched.
+- `--delay` (macOS only) to customize the delay (in milliseconds) between a webcam event being detected and toggling your Litra. When your webcam turns on or off, multiple events may be generated in quick succession. Setting a delay allows the program to wait for all events before taking action, avoiding flickering. Defaults to 1.5 seconds (1500 milliseconds).
 
 ## Configuring `udev` permissions (Linux only)
 


### PR DESCRIPTION
On my macOS machine, when my webcam turns on, multiple "webcam on" and "webcam off" events seem to be emitted in quick succession. This makes the Litra flicker in an frustrating, distracting way that can be a bit embarassing on video calls!

This PR introduces an automatic debounce mechanism on macOS, waiting for 1.5 seconds after an event before taking action. If a contradictory event comes in in the mean time, then nothing happens. So:

* If the webcam starts to turn on, and then turns off again 1 second later, the light will not be turned on.
* If the light starts to turn on, then quickly turns off then back on again in the next 1 second, the light will turn on, but will wait for 1.5 seconds to elapse.

The delay is customisable using the `--delay` argument, setting a delay in milliseconds, so you can shorten, extend or even eliminate the delay if you wish.

Related to #19, which reports similar issues on Linux - but when other applications access the camera, not when it is turned on/off for the first time.