### PR TITLE
Implement Linux delay functionality path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "litra-autotoggle"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "inotify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litra-autotoggle"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Tim Rogers <timrogers@github.com>"]
 description = "Automatically turn your Logitech Litra device on when your webcam turns on, and off when your webcam turns off (macOS and Linux only)"
@@ -22,9 +22,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5.27", features = ["derive"] }
 litra = "2.2.0"
+tokio = { version = "1.43.0", features = ["full"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 inotify = { version = "0.11.0" }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-tokio = { version = "1.43.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following arguments are supported:
 - `--serial-number` to point to a specific Litra device. You can get the serial number using the `litra devices` command in the [`litra`](https://github.com/timrogers/litra-rs) CLI.
 - `--require-device` to enforce that a Litra device must be connected. By default, the listener will keep running even if no Litra device is found. With this set, the listener will exit whenever it looks for a Litra device and none is found.
 - `--video-device` (Linux only) to watch a specific video device (e.g. `/dev/video0`). By default, all video devices will be watched.
-- `--delay` (macOS only) to customize the delay (in milliseconds) between a webcam event being detected and toggling your Litra. When your webcam turns on or off, multiple events may be generated in quick succession. Setting a delay allows the program to wait for all events before taking action, avoiding flickering. Defaults to 1.5 seconds (1500 milliseconds).
+- `--delay` to customize the delay (in milliseconds) between a webcam event being detected and toggling your Litra. When your webcam turns on or off, multiple events may be generated in quick succession. Setting a delay allows the program to wait for all events before taking action, avoiding flickering. Defaults to 1.5 seconds (1500 milliseconds).
 
 ## Configuring `udev` permissions (Linux only)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,6 @@ use std::process::ExitCode;
 use std::process::Stdio;
 use std::sync::Arc;
 #[cfg(target_os = "macos")]
-use std::sync::Arc;
-#[cfg(target_os = "macos")]
 use tokio::io::{AsyncBufReadExt, BufReader};
 #[cfg(target_os = "macos")]
 use tokio::process::Command;
@@ -396,12 +394,12 @@ async fn handle_autotoggle_command(
         }
         if num_devices_open == 0 {
             println!("Detected that a video device has been turned off, attempting to turn off Litra device...");
-
+            
             let mut state = desired_state.lock().await;
             *state = Some(false);
         } else {
             println!("Detected that a video device has been turned on, attempting to turn on Litra device...");
-
+            
             let mut state = desired_state.lock().await;
             *state = Some(true);
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -394,12 +394,12 @@ async fn handle_autotoggle_command(
         }
         if num_devices_open == 0 {
             println!("Detected that a video device has been turned off.");
-            
+
             let mut state = desired_state.lock().await;
             *state = Some(false);
         } else {
             println!("Detected that a video device has been turned on.");
-            
+
             let mut state = desired_state.lock().await;
             *state = Some(true);
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,12 +393,12 @@ async fn handle_autotoggle_command(
             }
         }
         if num_devices_open == 0 {
-            println!("Detected that a video device has been turned off, attempting to turn off Litra device...");
+            println!("Detected that a video device has been turned off.");
             
             let mut state = desired_state.lock().await;
             *state = Some(false);
         } else {
-            println!("Detected that a video device has been turned on, attempting to turn on Litra device...");
+            println!("Detected that a video device has been turned on.");
             
             let mut state = desired_state.lock().await;
             *state = Some(true);


### PR DESCRIPTION
This PR introduces a delay functionality for Linux, aligning it with the existing macOS implementation. The delay helps prevent flickering by ensuring that multiple rapid webcam events are handled as a single transition. Key updates include:

- **Linux Delay Support**: The `--delay` option is now available for Linux, allowing users to specify a debounce delay (default: 1500ms).
- **Async Processing with Tokio**:
  - Replaced synchronous Linux implementation with an asynchronous approach using `tokio`.
  - Introduced `Arc<Mutex<>>` for shared state management.
- **Device Toggle Throttling**:
  - Implemented a debounce mechanism to avoid redundant toggling of the Litra device.
  - Pending actions are canceled if a new event occurs within the delay period.

### Changes:

- Updated `Cargo.toml` to move `tokio` dependency to the global scope.
- Modified `handle_autotoggle_command` to be async for Linux.
- Introduced a throttling mechanism using `tokio::time::sleep` and `Arc<Mutex<Option<bool>>>` to prevent flickering.
- Updated `README.md` to reflect Linux delay support.

### Testing:

- Verified that the delay works correctly on Linux, ensuring no flickering occurs.

### Impact:

This change improves the stability of Litra device toggling on Linux by preventing unnecessary state changes, making it more consistent with macOS behavior.


Resolves #19 