### PR TITLE
Allow other packages to be installed and upgraded when installing `libudev-dev` in CI

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -45,7 +45,7 @@ jobs:
         run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
         if: matrix.job.runs_on == 'self-hosted'
       - name: Install libudev-dev
-        run: sudo apt-get update && sudo apt-get install libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
         if: runner.os == 'Linux'
       - uses: actions/checkout@v4
       - name: Use Rust 1.83.0 with target ${{ matrix.job.target }}
@@ -151,7 +151,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install libudev-dev
-        run: sudo apt-get update && sudo apt-get install libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
       - name: Use Rust 1.83.0
         run: rustup override set 1.83.0
       - uses: Swatinem/rust-cache@v2
@@ -206,7 +206,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install libudev-dev
-        run: sudo apt-get update && sudo apt-get install libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
       - name: Use Rust 1.83.0
         run: rustup override set 1.83.0
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
This should fix the new CI failure seen [here](https://github.com/timrogers/litra-autotoggle/actions/runs/13097500973/job/36541582492).