### PR TITLE
v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "litra-autotoggle"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "clap",
  "inotify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "litra-autotoggle"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 authors = ["Tim Rogers <timrogers@github.com>"]
 description = "Automatically turn your Logitech Litra device on when your webcam turns on, and off when your webcam turns off (macOS and Linux only)"


### PR DESCRIPTION
* Support configurable delay between detecting a webcam event and toggling the Litra on Linux (previously macOS only)