### PR TITLE
Build `linux-aarch64` binary on a GitHub-hosted runner, not a self-hosted runner

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -24,7 +24,7 @@ jobs:
           - {
               target: aarch64-unknown-linux-gnu,
               binary_name: linux-aarch64,
-              runs_on: self-hosted,
+              runs_on: ubuntu-24.04-arm,
             }
           - {
               target: x86_64-apple-darwin,


### PR DESCRIPTION
…sted runner