### PR TITLE
Add automatic update checking functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,27 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -67,10 +82,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
@@ -80,10 +107,11 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.28"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -92,6 +120,17 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -140,6 +179,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,10 +318,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -231,6 +400,148 @@ dependencies = [
  "libc",
  "pkg-config",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -302,16 +613,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "litra"
@@ -328,7 +665,9 @@ dependencies = [
 name = "litra-autotoggle"
 version = "1.3.0"
 dependencies = [
+ "chrono",
  "clap",
+ "dirs",
  "env_logger",
  "inotify",
  "litra",
@@ -337,8 +676,16 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tokio",
+ "toml",
+ "ureq",
  "winreg",
 ]
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -363,6 +710,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,10 +732,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -402,6 +780,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -429,6 +813,21 @@ checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -464,6 +863,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +903,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +928,47 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -561,6 +1026,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +1063,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,10 +1085,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -622,16 +1114,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -663,6 +1227,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,10 +1280,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+dependencies = [
+ "base64",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf-8",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -696,10 +1369,117 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -859,6 +1639,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +1662,95 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,16 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.5.54", features = ["derive"] }
+chrono = { version = "0.4.43", default-features = false, features = ["std", "clock"] }
+dirs = "6.0.0"
 env_logger = "0.11.5"
 litra = { version = "3.1.1", default-features = false }
 log = "0.4.29"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
+toml = "0.8.20"
 tokio = { version = "1.49.0", features = ["full"] }
+ureq = { version = "3.0.11", features = ["json"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 inotify = { version = "0.11.0" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,8 +283,10 @@ fn merge_config_with_cli(mut cli: Cli) -> Result<Cli, CliError> {
             }
         }
         // Only use config delay if CLI has the default value (1500)
-        if cli.delay == 1500 && config.delay.is_some() {
-            cli.delay = config.delay.unwrap();
+        if cli.delay == 1500 {
+            if let Some(delay) = config.delay {
+                cli.delay = delay;
+            }
         }
         if !cli.verbose {
             cli.verbose = config.verbose.unwrap_or(false);
@@ -469,10 +471,10 @@ fn turn_off_all_supported_devices_and_log(
 }
 
 fn print_device_not_found_log(serial_number: Option<&str>) {
-    if serial_number.is_some() {
+    if let Some(serial_number) = serial_number {
         warn!(
             "Litra device with serial number {} not found",
-            serial_number.unwrap()
+            serial_number
         );
     } else {
         warn!("No Litra devices found");

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,11 @@ struct AppConfig {
 
 /// Automatically turn your Logitech Litra device on when your webcam turns on, and off when your webcam turns off.
 #[derive(Debug, Parser)]
-#[clap(name = "litra-autotoggle", version, after_long_help = "This CLI automatically checks for updates once per day. To disable update checks, set the LITRA_AUTOTOGGLE_DISABLE_UPDATE_CHECK environment variable to any value.")]
+#[clap(
+    name = "litra-autotoggle",
+    version,
+    after_long_help = "This CLI automatically checks for updates once per day. To disable update checks, set the LITRA_AUTOTOGGLE_DISABLE_UPDATE_CHECK environment variable to any value."
+)]
 struct Cli {
     #[clap(
         long,
@@ -965,8 +969,7 @@ fn is_camera_active(app_key: &RegKey) -> bool {
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// GitHub API URL for fetching releases (list endpoint)
-const GITHUB_API_URL: &str =
-    "https://api.github.com/repos/timrogers/litra-autotoggle/releases";
+const GITHUB_API_URL: &str = "https://api.github.com/repos/timrogers/litra-autotoggle/releases";
 
 /// Timeout for update check requests in seconds
 const UPDATE_CHECK_TIMEOUT_SECS: u64 = 2;
@@ -1116,7 +1119,10 @@ fn check_for_updates() -> Option<String> {
 
     let mut response = match agent
         .get(GITHUB_API_URL)
-        .header("User-Agent", format!("litra-autotoggle/{}", CURRENT_VERSION))
+        .header(
+            "User-Agent",
+            format!("litra-autotoggle/{}", CURRENT_VERSION),
+        )
         .header("Accept", "application/vnd.github.v3+json")
         .call()
     {
@@ -1351,8 +1357,7 @@ mod tests {
     #[test]
     fn test_should_check_for_updates_checked_long_ago() {
         let mut config = UpdateConfig::default();
-        config.update_check.last_check_timestamp =
-            Some(current_timestamp() - SECONDS_PER_DAY - 1);
+        config.update_check.last_check_timestamp = Some(current_timestamp() - SECONDS_PER_DAY - 1);
         assert!(should_check_for_updates(&config));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use winreg::RegKey;
 /// Field names use underscores to match YAML convention (e.g. serial_number).
 #[derive(Debug, Deserialize, Serialize, Default)]
 #[serde(deny_unknown_fields)]
-struct Config {
+struct AppConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     serial_number: Option<String>,
 
@@ -56,7 +56,7 @@ struct Config {
 
 /// Automatically turn your Logitech Litra device on when your webcam turns on, and off when your webcam turns off.
 #[derive(Debug, Parser)]
-#[clap(name = "litra-autotoggle", version)]
+#[clap(name = "litra-autotoggle", version, after_long_help = "This CLI automatically checks for updates once per day. To disable update checks, set the LITRA_AUTOTOGGLE_DISABLE_UPDATE_CHECK environment variable to any value.")]
 struct Cli {
     #[clap(
         long,
@@ -229,13 +229,13 @@ fn validate_device_type(device_type: &str) -> Result<(), CliError> {
 }
 
 /// Loads and validates the configuration from a YAML file
-fn load_config_file(config_path: &PathBuf) -> Result<Config, CliError> {
+fn load_config_file(config_path: &PathBuf) -> Result<AppConfig, CliError> {
     // Read the file
     let contents = fs::read_to_string(config_path)
         .map_err(|e| CliError::ConfigFileError(format!("Failed to read config file: {}", e)))?;
 
     // Parse YAML
-    let config: Config = serde_yaml::from_str(&contents)
+    let config: AppConfig = serde_yaml::from_str(&contents)
         .map_err(|e| CliError::ConfigFileError(format!("Failed to parse YAML: {}", e)))?;
 
     // Validate device_type if specified
@@ -961,6 +961,215 @@ fn is_camera_active(app_key: &RegKey) -> bool {
     }
 }
 
+/// The current version of the CLI, extracted from Cargo.toml
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// GitHub API URL for fetching releases (list endpoint)
+const GITHUB_API_URL: &str =
+    "https://api.github.com/repos/timrogers/litra-autotoggle/releases";
+
+/// Timeout for update check requests in seconds
+const UPDATE_CHECK_TIMEOUT_SECS: u64 = 2;
+
+/// Response structure for GitHub releases API
+#[derive(serde::Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    published_at: String,
+}
+
+/// Configuration file name for storing update check state
+const UPDATE_CONFIG_FILE_NAME: &str = ".litra-autotoggle.toml";
+
+/// Number of seconds in a day (24 hours)
+const SECONDS_PER_DAY: u64 = 86400;
+
+/// Configuration structure for the TOML update check state file
+#[derive(serde::Deserialize, serde::Serialize, Default)]
+struct UpdateConfig {
+    #[serde(default)]
+    update_check: UpdateCheckConfig,
+}
+
+/// Update check configuration
+#[derive(serde::Deserialize, serde::Serialize, Default)]
+struct UpdateCheckConfig {
+    /// Unix timestamp of the last update check
+    last_check_timestamp: Option<u64>,
+}
+
+/// Returns the path to the update config file in the user's home directory
+fn get_update_config_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|home| home.join(UPDATE_CONFIG_FILE_NAME))
+}
+
+/// Reads the update config file, returning a default config if the file doesn't exist or can't be read
+fn read_update_config() -> UpdateConfig {
+    let Some(config_path) = get_update_config_path() else {
+        return UpdateConfig::default();
+    };
+
+    match std::fs::read_to_string(&config_path) {
+        Ok(contents) => toml::from_str(&contents).unwrap_or_default(),
+        Err(_) => UpdateConfig::default(),
+    }
+}
+
+/// Writes the update config to the config file, silently ignoring errors
+fn write_update_config(config: &UpdateConfig) {
+    let Some(config_path) = get_update_config_path() else {
+        return;
+    };
+
+    if let Ok(contents) = toml::to_string_pretty(config) {
+        let _ = std::fs::write(&config_path, contents);
+    }
+}
+
+/// Returns the current Unix timestamp in seconds
+fn current_timestamp() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Checks if enough time has passed since the last update check (at least one day)
+fn should_check_for_updates(config: &UpdateConfig) -> bool {
+    let Some(last_check) = config.update_check.last_check_timestamp else {
+        return true; // Never checked before
+    };
+
+    let now = current_timestamp();
+    now.saturating_sub(last_check) >= SECONDS_PER_DAY
+}
+
+/// Checks if a release is old enough to be considered for update notifications (at least 72 hours)
+fn is_release_old_enough(published_at: &str) -> bool {
+    use chrono::{DateTime, Duration, Utc};
+
+    let Ok(release_time) = DateTime::parse_from_rfc3339(published_at) else {
+        return false;
+    };
+
+    let cutoff = Utc::now() - Duration::hours(72);
+    release_time < cutoff
+}
+
+/// Environment variable to disable update checks
+const DISABLE_UPDATE_CHECK_ENV: &str = "LITRA_AUTOTOGGLE_DISABLE_UPDATE_CHECK";
+
+/// Compares two semantic version strings to determine if `latest` is newer than `current`.
+/// Returns true if `latest` is a newer version.
+fn is_newer_version(latest: &str, current: &str) -> bool {
+    let parse_version = |v: &str| -> Option<(u32, u32, u32)> {
+        let parts: Vec<&str> = v.split('.').collect();
+        if parts.len() >= 3 {
+            Some((
+                parts[0].parse().ok()?,
+                parts[1].parse().ok()?,
+                parts[2].parse().ok()?,
+            ))
+        } else if parts.len() == 2 {
+            Some((parts[0].parse().ok()?, parts[1].parse().ok()?, 0))
+        } else if parts.len() == 1 {
+            Some((parts[0].parse().ok()?, 0, 0))
+        } else {
+            None
+        }
+    };
+
+    match (parse_version(latest), parse_version(current)) {
+        (Some((l_major, l_minor, l_patch)), Some((c_major, c_minor, c_patch))) => {
+            (l_major, l_minor, l_patch) > (c_major, c_minor, c_patch)
+        }
+        _ => false,
+    }
+}
+
+/// Checks for updates by fetching releases from GitHub.
+/// Returns the latest version tag if a newer version is available, None otherwise.
+/// This function will timeout after 2 seconds but will not disrupt normal operation.
+/// Set the LITRA_AUTOTOGGLE_DISABLE_UPDATE_CHECK environment variable to disable this check.
+/// The check is performed at most once per day, with the last check time stored in ~/.litra-autotoggle.toml.
+/// Only releases that are at least 72 hours old are considered.
+fn check_for_updates() -> Option<String> {
+    if std::env::var(DISABLE_UPDATE_CHECK_ENV).is_ok() {
+        return None;
+    }
+
+    let mut config = read_update_config();
+    if !should_check_for_updates(&config) {
+        return None;
+    }
+
+    config.update_check.last_check_timestamp = Some(current_timestamp());
+    write_update_config(&config);
+
+    let timeout = std::time::Duration::from_secs(UPDATE_CHECK_TIMEOUT_SECS);
+
+    let agent = ureq::Agent::new_with_config(
+        ureq::Agent::config_builder()
+            .timeout_global(Some(timeout))
+            .build(),
+    );
+
+    let mut response = match agent
+        .get(GITHUB_API_URL)
+        .header("User-Agent", format!("litra-autotoggle/{}", CURRENT_VERSION))
+        .header("Accept", "application/vnd.github.v3+json")
+        .call()
+    {
+        Ok(response) => response,
+        Err(e) => {
+            if let ureq::Error::Timeout(_) = e {
+                eprintln!(
+                    "Warning: Update check timed out after {} seconds",
+                    UPDATE_CHECK_TIMEOUT_SECS
+                );
+            }
+            return None;
+        }
+    };
+
+    let releases: Vec<GitHubRelease> = match response.body_mut().read_json() {
+        Ok(releases) => releases,
+        Err(_) => return None,
+    };
+
+    let mut best_version: Option<String> = None;
+
+    for release in releases {
+        if !is_release_old_enough(&release.published_at) {
+            continue;
+        }
+
+        let release_version = release.tag_name.trim_start_matches('v');
+
+        if is_newer_version(release_version, CURRENT_VERSION) {
+            match &best_version {
+                None => best_version = Some(release.tag_name),
+                Some(current_best) => {
+                    let current_best_version = current_best.trim_start_matches('v');
+                    if is_newer_version(release_version, current_best_version) {
+                        best_version = Some(release.tag_name);
+                    }
+                }
+            }
+        }
+    }
+
+    best_version
+}
+
+/// Generates the update notification message for the given version
+fn format_update_message(latest_version: &str) -> String {
+    format!(
+        "A new version of litra-autotoggle is available: {} (current: v{}). Download the latest release at https://github.com/timrogers/litra-autotoggle/releases/tag/{}",
+        latest_version, CURRENT_VERSION, latest_version
+    )
+}
+
 #[cfg(target_os = "macos")]
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -977,6 +1186,10 @@ async fn main() -> ExitCode {
 
     let log_level = if args.verbose { "debug" } else { "info" };
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(log_level)).init();
+
+    if let Some(latest_version) = check_for_updates() {
+        warn!("{}", format_update_message(&latest_version));
+    }
 
     let result = handle_autotoggle_command(
         args.serial_number.as_deref(),
@@ -1012,6 +1225,10 @@ async fn main() -> ExitCode {
 
     let log_level = if args.verbose { "debug" } else { "info" };
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(log_level)).init();
+
+    if let Some(latest_version) = check_for_updates() {
+        warn!("{}", format_update_message(&latest_version));
+    }
 
     let result = handle_autotoggle_command(
         args.serial_number.as_deref(),
@@ -1049,6 +1266,10 @@ async fn main() -> ExitCode {
     let log_level = if args.verbose { "debug" } else { "info" };
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(log_level)).init();
 
+    if let Some(latest_version) = check_for_updates() {
+        warn!("{}", format_update_message(&latest_version));
+    }
+
     let result = handle_autotoggle_command(
         args.serial_number.as_deref(),
         args.device_path.as_deref(),
@@ -1072,6 +1293,92 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_is_newer_version_major() {
+        assert!(is_newer_version("4.0.0", "3.2.0"));
+        assert!(is_newer_version("2.0.0", "1.0.0"));
+        assert!(!is_newer_version("1.0.0", "2.0.0"));
+        assert!(!is_newer_version("3.0.0", "4.0.0"));
+    }
+
+    #[test]
+    fn test_is_newer_version_minor() {
+        assert!(is_newer_version("1.4.0", "1.3.0"));
+        assert!(is_newer_version("1.2.0", "1.1.0"));
+        assert!(!is_newer_version("1.1.0", "1.2.0"));
+        assert!(!is_newer_version("1.3.0", "1.4.0"));
+    }
+
+    #[test]
+    fn test_is_newer_version_patch() {
+        assert!(is_newer_version("1.3.1", "1.3.0"));
+        assert!(is_newer_version("1.0.5", "1.0.4"));
+        assert!(!is_newer_version("1.0.4", "1.0.5"));
+        assert!(!is_newer_version("1.3.0", "1.3.1"));
+    }
+
+    #[test]
+    fn test_is_newer_version_same_version() {
+        assert!(!is_newer_version("1.3.0", "1.3.0"));
+        assert!(!is_newer_version("1.0.0", "1.0.0"));
+    }
+
+    #[test]
+    fn test_is_newer_version_edge_cases() {
+        assert!(is_newer_version("2.0", "1.9"));
+        assert!(!is_newer_version("1.9", "2.0"));
+        assert!(is_newer_version("2", "1"));
+        assert!(!is_newer_version("1", "2"));
+        assert!(!is_newer_version("invalid", "1.3.0"));
+        assert!(!is_newer_version("1.3.0", "invalid"));
+        assert!(!is_newer_version("", "1.3.0"));
+    }
+
+    #[test]
+    fn test_should_check_for_updates_never_checked() {
+        let config = UpdateConfig::default();
+        assert!(should_check_for_updates(&config));
+    }
+
+    #[test]
+    fn test_should_check_for_updates_checked_recently() {
+        let mut config = UpdateConfig::default();
+        config.update_check.last_check_timestamp = Some(current_timestamp());
+        assert!(!should_check_for_updates(&config));
+    }
+
+    #[test]
+    fn test_should_check_for_updates_checked_long_ago() {
+        let mut config = UpdateConfig::default();
+        config.update_check.last_check_timestamp =
+            Some(current_timestamp() - SECONDS_PER_DAY - 1);
+        assert!(should_check_for_updates(&config));
+    }
+
+    #[test]
+    fn test_should_check_for_updates_exactly_one_day() {
+        let mut config = UpdateConfig::default();
+        config.update_check.last_check_timestamp = Some(current_timestamp() - SECONDS_PER_DAY);
+        assert!(should_check_for_updates(&config));
+    }
+
+    #[test]
+    fn test_is_release_old_enough() {
+        assert!(is_release_old_enough("2020-01-01T00:00:00Z"));
+        assert!(!is_release_old_enough("2099-01-01T00:00:00Z"));
+        assert!(!is_release_old_enough("invalid"));
+    }
+
+    #[test]
+    fn test_format_update_message() {
+        let message = format_update_message("v1.4.0");
+        assert!(message.contains("v1.4.0"));
+        assert!(message.contains(CURRENT_VERSION));
+        assert!(
+            message.contains("https://github.com/timrogers/litra-autotoggle/releases/tag/v1.4.0")
+        );
+    }
 
     /// Helper function to create a temporary YAML file with given content
     fn create_temp_config(content: &str) -> NamedTempFile {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1173,7 +1173,7 @@ fn check_for_updates() -> Option<String> {
 /// Generates the update notification message for the given version
 fn format_update_message(latest_version: &str) -> String {
     format!(
-        "A new version of litra-autotoggle is available: {} (current: v{}). Download the latest release at https://github.com/timrogers/litra-autotoggle/releases/tag/{}",
+        "A new version of litra-autotoggle is available: {} (current: v{}). If you installed from Homebrew, you can upgrade by running `brew upgrade litra-autotoggle`. Otherwise, you can download the latest release at https://github.com/timrogers/litra-autotoggle/releases/tag/{}",
         latest_version, CURRENT_VERSION, latest_version
     )
 }
@@ -1196,7 +1196,7 @@ async fn main() -> ExitCode {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(log_level)).init();
 
     if let Some(latest_version) = check_for_updates() {
-        warn!("{}", format_update_message(&latest_version));
+        info!("{}", format_update_message(&latest_version));
     }
 
     let result = handle_autotoggle_command(
@@ -1235,7 +1235,7 @@ async fn main() -> ExitCode {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(log_level)).init();
 
     if let Some(latest_version) = check_for_updates() {
-        warn!("{}", format_update_message(&latest_version));
+        info!("{}", format_update_message(&latest_version));
     }
 
     let result = handle_autotoggle_command(
@@ -1275,7 +1275,7 @@ async fn main() -> ExitCode {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(log_level)).init();
 
     if let Some(latest_version) = check_for_updates() {
-        warn!("{}", format_update_message(&latest_version));
+        info!("{}", format_update_message(&latest_version));
     }
 
     let result = handle_autotoggle_command(
@@ -1382,6 +1382,7 @@ mod tests {
         let message = format_update_message("v1.4.0");
         assert!(message.contains("v1.4.0"));
         assert!(message.contains(CURRENT_VERSION));
+        assert!(message.contains("brew upgrade litra-autotoggle"));
         assert!(
             message.contains("https://github.com/timrogers/litra-autotoggle/releases/tag/v1.4.0")
         );


### PR DESCRIPTION
## Summary
This PR adds automatic update checking to litra-autotoggle. The application now checks for new releases on GitHub once per day and notifies users when updates are available.

## Key Changes
- **Renamed `Config` struct to `AppConfig`** for clarity and to avoid naming conflicts with the new update configuration system
- **Added update checking system** that:
  - Fetches releases from the GitHub API with a 2-second timeout
  - Caches the last check timestamp in `~/.litra-autotoggle.toml` to limit checks to once per day
  - Only considers releases that are at least 72 hours old to avoid notifying about very recent releases
  - Can be disabled via the `LITRA_AUTOTOGGLE_DISABLE_UPDATE_CHECK` environment variable
- **Integrated update checks into all platform-specific main functions** (macOS, Linux, Windows) to display warning messages when updates are available
- **Added comprehensive version comparison logic** that properly handles semantic versioning (major.minor.patch format with flexible parsing)
- **Updated CLI help text** to document the update check feature and how to disable it
- **Added extensive test coverage** for version comparison, update check timing, and release age validation

## Implementation Details
- Uses `ureq` for lightweight HTTP requests with timeout support
- Stores update check state in TOML format in the user's home directory
- Gracefully handles network timeouts and API errors without disrupting normal operation
- Implements semantic version comparison that handles various version string formats (e.g., "1.2.3", "1.2", "1")
- Uses `chrono` for RFC3339 timestamp parsing to determine release age

https://claude.ai/code/session_01Dhy8pUL2ZHYuygG8WKiTMa